### PR TITLE
feat: further customise highlight colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ return {
 - `showBlankVirtLine = false`
   Setting this option will mean that if a Virtual Line would be blank it wont be
   rendered
+- `highlightColor` can be a string or a highlight table. If it's a string, it
+  must be a valid highlight, see `:highlight`. It can also be a table that defines
+  a set of [highlight values](https://neovim.io/doc/user/api.html#nvim_set_hl()).
+
 
 ## ❔Usage
 

--- a/README.md
+++ b/README.md
@@ -52,9 +52,10 @@ return {
 - `showBlankVirtLine = false`
   Setting this option will mean that if a Virtual Line would be blank it wont be
   rendered
-- `highlightColor` is set as a highlight table. It can be a `link` field
-  that must be a valid highlight, see `:highlight`. It can also be a table that defines
-  a set of custom [highlight values](<https://neovim.io/doc/user/api.html#nvim_set_hl()>).
+- highlightColor can be set in two ways:
+
+1. As a table containing a link property pointing to an existing highlight group (see `:highlight` for valid options).
+2. As a table specifying custom highlight values, such as foreground and background colors. ([more info](<https://neovim.io/doc/user/api.html#nvim_set_hl()>))
 
 ## ❔Usage
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ return {
     config = {
     -- startVisible = true,
     -- showBlankVirtLine = true,
-    -- highlightColor = "Comment",
+    -- highlightColor = { link = "Comment"),
     -- hints = {
     --      Caret = { text = "^", prio = 2 },
     --      Dollar = { text = "$", prio = 1 },
@@ -52,10 +52,9 @@ return {
 - `showBlankVirtLine = false`
   Setting this option will mean that if a Virtual Line would be blank it wont be
   rendered
-- `highlightColor` can be a string or a highlight table. If it's a string, it
-  must be a valid highlight, see `:highlight`. It can also be a table that defines
-  a set of [highlight values](https://neovim.io/doc/user/api.html#nvim_set_hl()).
-
+- `highlightColor` is set as a highlight table. It can be a `link` field
+  that must be a valid highlight, see `:highlight`. It can also be a table that defines
+  a set of custom [highlight values](<https://neovim.io/doc/user/api.html#nvim_set_hl()>).
 
 ## ❔Usage
 

--- a/lua/precognition/init.lua
+++ b/lua/precognition/init.lua
@@ -35,7 +35,7 @@ local M = {}
 ---@class Precognition.PartialConfig
 ---@field startVisible? boolean
 ---@field showBlankVirtLine? boolean
----@field highlightColor? string
+---@field highlightColor? string | vim.api.keyset.highlight
 ---@field hints? Precognition.HintConfig
 ---@field gutterHints? Precognition.GutterHintConfig
 
@@ -355,6 +355,13 @@ function M.setup(opts)
 
     ns = vim.api.nvim_create_namespace("precognition")
     au = vim.api.nvim_create_augroup("precognition", { clear = true })
+
+    if type(config.highlightColor) == "table" then
+      vim.api.nvim_set_hl(ns, "precognition", config.highlightColor)
+      vim.api.nvim_set_hl_ns(ns)
+      config.highlightColor = "precognition"
+    end
+
     if config.startVisible then
         M.show()
     end

--- a/lua/precognition/init.lua
+++ b/lua/precognition/init.lua
@@ -357,9 +357,10 @@ function M.setup(opts)
     au = vim.api.nvim_create_augroup("precognition", { clear = true })
 
     if type(config.highlightColor) == "table" then
-      vim.api.nvim_set_hl(ns, "precognition", config.highlightColor)
-      vim.api.nvim_set_hl_ns(ns)
-      config.highlightColor = "precognition"
+        local hl_name = "Precognition"
+        vim.api.nvim_set_hl(ns, hl_name, config.highlightColor)
+        vim.api.nvim_set_hl_ns(ns)
+        config.highlightColor = hl_name
     end
 
     if config.startVisible then

--- a/tests/precognition/e2e_spec.lua
+++ b/tests/precognition/e2e_spec.lua
@@ -16,6 +16,17 @@ local function get_gutter_extmarks(buffer)
     return gutter_extmarks
 end
 
+local function hex2dec(hex)
+    hex = hex:gsub("#", "")
+    local r = tonumber("0x" .. hex:sub(1, 2))
+    local g = tonumber("0x" .. hex:sub(3, 4))
+    local b = tonumber("0x" .. hex:sub(5, 6))
+
+    local dec = (r * 256 ^ 2) + (g * 256) + b
+
+    return dec
+end
+
 describe("e2e tests", function()
     before_each(function()
         precognition.setup({})
@@ -58,16 +69,17 @@ describe("e2e tests", function()
 
         for _, extmark in pairs(gutter_extmarks) do
             if extmark[4].sign_text == "G " then
-                eq("Comment", extmark[4].sign_hl_group)
+                eq("PrecognitionHighlight", extmark[4].sign_hl_group)
+                eq({ link = "Comment" }, vim.api.nvim_get_hl(0, { name = extmark[4].sign_hl_group }))
                 eq(5, extmark[2])
             elseif extmark[4].sign_text == "gg" then
-                eq("Comment", extmark[4].sign_hl_group)
+                eq("PrecognitionHighlight", extmark[4].sign_hl_group)
                 eq(0, extmark[2])
             elseif extmark[4].sign_text == "{ " then
-                eq("Comment", extmark[4].sign_hl_group)
+                eq("PrecognitionHighlight", extmark[4].sign_hl_group)
                 eq(0, extmark[2])
             elseif extmark[4].sign_text == "} " then
-                eq("Comment", extmark[4].sign_hl_group)
+                eq("PrecognitionHighlight", extmark[4].sign_hl_group)
                 eq(2, extmark[2])
             else
                 assert(false, "unexpected sign text")
@@ -76,7 +88,8 @@ describe("e2e tests", function()
 
         eq(vim.api.nvim_win_get_cursor(0)[1] - 1, extmarks[1])
         eq("b   e w                  $", extmarks[3].virt_lines[1][1][1])
-        eq("Comment", extmarks[3].virt_lines[1][1][2])
+        eq("PrecognitionHighlight", extmarks[3].virt_lines[1][1][2])
+        eq({ link = "Comment" }, vim.api.nvim_get_hl(0, { name = extmarks[3].virt_lines[1][1][2] }))
 
         vim.api.nvim_win_set_cursor(0, { 1, 6 })
         precognition.on_cursor_moved()
@@ -134,7 +147,7 @@ describe("e2e tests", function()
     end)
 
     it("virtual line text color can be customised", function()
-        precognition.setup({ highlightColor = "Function" })
+        precognition.setup({ highlightColor = { link = "Function" } })
         local buffer = vim.api.nvim_create_buf(true, false)
         vim.api.nvim_set_current_buf(buffer)
         vim.api.nvim_buf_set_lines(
@@ -156,16 +169,20 @@ describe("e2e tests", function()
 
         for _, extmark in pairs(gutter_extmarks) do
             if extmark[4].sign_text == "G " then
-                eq("Function", extmark[4].sign_hl_group)
+                eq("PrecognitionHighlight", extmark[4].sign_hl_group)
+                eq({ link = "Function" }, vim.api.nvim_get_hl(0, { name = extmark[4].sign_hl_group }))
                 eq(5, extmark[2])
             elseif extmark[4].sign_text == "gg" then
-                eq("Function", extmark[4].sign_hl_group)
+                eq("PrecognitionHighlight", extmark[4].sign_hl_group)
+                eq({ link = "Function" }, vim.api.nvim_get_hl(0, { name = extmark[4].sign_hl_group }))
                 eq(0, extmark[2])
             elseif extmark[4].sign_text == "{ " then
-                eq("Function", extmark[4].sign_hl_group)
+                eq("PrecognitionHighlight", extmark[4].sign_hl_group)
+                eq({ link = "Function" }, vim.api.nvim_get_hl(0, { name = extmark[4].sign_hl_group }))
                 eq(0, extmark[2])
             elseif extmark[4].sign_text == "} " then
-                eq("Function", extmark[4].sign_hl_group)
+                eq("PrecognitionHighlight", extmark[4].sign_hl_group)
+                eq({ link = "Function" }, vim.api.nvim_get_hl(0, { name = extmark[4].sign_hl_group }))
                 eq(2, extmark[2])
             else
                 assert(false, "unexpected sign text")
@@ -174,6 +191,60 @@ describe("e2e tests", function()
 
         eq(vim.api.nvim_win_get_cursor(0)[1] - 1, extmarks[1])
         eq("b   e w                  $", extmarks[3].virt_lines[1][1][1])
-        eq("Function", extmarks[3].virt_lines[1][1][2])
+        eq("PrecognitionHighlight", extmarks[3].virt_lines[1][1][2])
+        eq({ link = "Function" }, vim.api.nvim_get_hl(0, { name = extmarks[3].virt_lines[1][1][2] }))
+    end)
+
+    it("virtual line can be customised without a link", function()
+        local background = "#00ff00"
+        local foreground = "#ff0000"
+        local customColor = { foreground = foreground, background = background }
+        local customMark = { fg = hex2dec(foreground), bg = hex2dec(background) }
+        precognition.setup({ highlightColor = customColor })
+        local buffer = vim.api.nvim_create_buf(true, false)
+        vim.api.nvim_set_current_buf(buffer)
+        vim.api.nvim_buf_set_lines(
+            buffer,
+            0,
+            -1,
+            false,
+            { "Hello World this is a test", "line 2", "", "line 4", "", "line 6" }
+        )
+        vim.api.nvim_win_set_cursor(0, { 1, 1 })
+
+        precognition.on_cursor_moved()
+
+        local extmarks = vim.api.nvim_buf_get_extmark_by_id(buffer, precognition.ns, precognition.extmark, {
+            details = true,
+        })
+
+        local gutter_extmarks = get_gutter_extmarks(buffer)
+
+        for _, extmark in pairs(gutter_extmarks) do
+            if extmark[4].sign_text == "G " then
+                eq("PrecognitionHighlight", extmark[4].sign_hl_group)
+                eq(customMark, vim.api.nvim_get_hl(0, { name = extmark[4].sign_hl_group }))
+                eq(5, extmark[2])
+            elseif extmark[4].sign_text == "gg" then
+                eq("PrecognitionHighlight", extmark[4].sign_hl_group)
+                eq(customMark, vim.api.nvim_get_hl(0, { name = extmark[4].sign_hl_group }))
+                eq(0, extmark[2])
+            elseif extmark[4].sign_text == "{ " then
+                eq("PrecognitionHighlight", extmark[4].sign_hl_group)
+                eq(customMark, vim.api.nvim_get_hl(0, { name = extmark[4].sign_hl_group }))
+                eq(0, extmark[2])
+            elseif extmark[4].sign_text == "} " then
+                eq("PrecognitionHighlight", extmark[4].sign_hl_group)
+                eq(customMark, vim.api.nvim_get_hl(0, { name = extmark[4].sign_hl_group }))
+                eq(2, extmark[2])
+            else
+                assert(false, "unexpected sign text")
+            end
+        end
+
+        eq(vim.api.nvim_win_get_cursor(0)[1] - 1, extmarks[1])
+        eq("b   e w                  $", extmarks[3].virt_lines[1][1][1])
+        eq("PrecognitionHighlight", extmarks[3].virt_lines[1][1][2])
+        eq(customMark, vim.api.nvim_get_hl(0, { name = extmarks[3].virt_lines[1][1][2] }))
     end)
 end)


### PR DESCRIPTION
This adds the ability to define custom colors for the precognition highlight. This allows you to not have to rely in exisiting highlight values. It does this by creating a new highlight if the config for `highlightColor` is a table, otherwise it falls back to using the string specified as the highlight.

This is a very quick implementation based on some poking around and the code diff from #28 so it might not be considered good enough as it currently stands. In particular:
- I'm unsure on how to set the correct `@field` type spec for the `highlightColor` now, and as a result the LSP complains that the call to `nvim_set_hl` doesn't accept a string, even though we know it is a table.
- It may not be desirable for the entire set of highlight values to be configured. This may wish to be restricted to a subset.
- I'm unsure if I'm creating custom highlights in the correct manner. There is an option to create in the global namespace by passing the value `0` instead of `ns` as the first argument to `nvim_set_hl` and this might be preferable.
- I might have broken the tests introduced in #28 or at the very least, now added a feature not covered by the tests. This part is outside my knowledge and experience.
- I might have selected the wrong branch to merge to. Apologies if I've done something incorrect in creating this pull request, I'm new to this.