### PR TITLE
feat: Introduce Lua type checking GitHub workflow

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,0 +1,21 @@
+---
+name: lua_ls-typecheck
+
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+    branches:
+      - "main"
+
+jobs:
+  build:
+    name: Type Check Code Base
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: stevearc/nvim-typecheck-action@v2
+        with:
+          level: Warning


### PR DESCRIPTION
This commit adds a new GitHub workflow for type checking the Lua codebase. The workflow is triggered on push and pull requests to the main branch. It utilizes the stevearc/nvim-typecheck-action@v2 action and is set to a warning level.