### PR TITLE
perf: inline `require` calls to minimize startup cost

### DIFF
--- a/lua/precognition/horizontal_motions.lua
+++ b/lua/precognition/horizontal_motions.lua
@@ -1,6 +1,3 @@
-local utils = require("precognition.utils")
-local cc = utils.char_classes
-
 local M = {}
 
 local supportedBrackets = {
@@ -31,6 +28,9 @@ end
 ---@param big_word boolean
 ---@return Precognition.PlaceLoc
 function M.next_word_boundary(str, cursorcol, linelen, big_word)
+    local utils = require("precognition.utils")
+    local cc = utils.char_classes
+
     local offset = cursorcol
     local char = vim.fn.strcharpart(str, offset - 1, 1)
     local c_class = utils.char_class(char, big_word)
@@ -62,6 +62,9 @@ function M.end_of_word(str, cursorcol, linelen, big_word)
     if cursorcol >= linelen then
         return 0
     end
+    local utils = require("precognition.utils")
+    local cc = utils.char_classes
+
     local offset = cursorcol
     local char = vim.fn.strcharpart(str, offset - 1, 1)
     local c_class = utils.char_class(char, big_word)
@@ -118,6 +121,9 @@ end
 ---@param big_word boolean
 ---@return Precognition.PlaceLoc
 function M.prev_word_boundary(str, cursorcol, linelen, big_word)
+    local utils = require("precognition.utils")
+    local cc = utils.char_classes
+
     local offset = cursorcol - 1
     local char = vim.fn.strcharpart(str, offset - 1, 1)
     local c_class = utils.char_class(char, big_word)

--- a/lua/precognition/init.lua
+++ b/lua/precognition/init.lua
@@ -1,7 +1,3 @@
-local hm = require("precognition.horizontal_motions")
-local vm = require("precognition.vertical_motions")
-local utils = require("precognition.utils")
-
 local M = {}
 
 ---@class Precognition.HintOpts
@@ -119,7 +115,7 @@ local function build_virt_line(marks, line_len, extra_padding)
         return {}
     end
     local virt_line = {}
-    local line_table = utils.create_pad_array(line_len, " ")
+    local line_table = require("precognition.utils").create_pad_array(line_len, " ")
 
     for mark, loc in pairs(marks) do
         local hint = config.hints[mark].text or mark
@@ -161,6 +157,7 @@ end
 
 ---@return Precognition.GutterHints
 local function build_gutter_hints()
+    local vm = require("precognition.vertical_motions")
     ---@type Precognition.GutterHints
     local gutter_hints = {
         G = vm.file_end(),
@@ -176,7 +173,7 @@ end
 ---@return nil
 local function apply_gutter_hints(gutter_hints, bufnr)
     bufnr = bufnr or vim.api.nvim_get_current_buf()
-    if utils.is_blacklisted_buffer(bufnr) then
+    if require("precognition.utils").is_blacklisted_buffer(bufnr) then
         return
     end
 
@@ -224,7 +221,7 @@ end
 
 local function display_marks()
     local bufnr = vim.api.nvim_get_current_buf()
-    if utils.is_blacklisted_buffer(bufnr) then
+    if require("precognition.utils").is_blacklisted_buffer(bufnr) then
         return
     end
     local cursorline = vim.fn.line(".")
@@ -242,6 +239,8 @@ local function display_marks()
     -- local before_cursor = vim.fn.strcharpart(cur_line, 0, cursorcol - 1)
     -- local before_cursor_rev = string.reverse(before_cursor)
     -- local under_cursor = vim.fn.strcharpart(cur_line, cursorcol - 1, 1)
+
+    local hm = require("precognition.horizontal_motions")
 
     -- FIXME: Lua patterns don't play nice with utf-8, we need a better way to
     -- get char offsets for more complex motions.
@@ -261,7 +260,8 @@ local function display_marks()
     }
 
     --multicharacter padding
-    utils.add_multibyte_padding(cur_line, extra_padding, line_len)
+
+    require("precognition.utils").add_multibyte_padding(cur_line, extra_padding, line_len)
 
     local virt_line = build_virt_line(virtual_line_marks, line_len, extra_padding)
 


### PR DESCRIPTION
Not that I've noticed any problems with startup time, but this should ensure that precognition has very minimal overhead until it's started.