### PR TITLE
docs: lazy opts in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Installation with any package manager, Lazy example below:
 return {
     "tris203/precognition.nvim",
     --event = "VeryLazy",
-    config = {
+    opts = {
     -- startVisible = true,
     -- showBlankVirtLine = true,
     -- highlightColor = { link = "Comment" },


### PR DESCRIPTION
`config` expects a function or `true` as a value. `opts` is what you're looking for when passing in a table of options.

See here for the lazy.nvim plugin specification 🙂 
https://github.com/folke/lazy.nvim?tab=readme-ov-file#-plugin-spec