### PR TITLE
fix(horizontal_motions): handle quoted strings in word boundaries

### DIFF
--- a/lua/precognition/horizontal_motions.lua
+++ b/lua/precognition/horizontal_motions.lua
@@ -96,7 +96,7 @@ function M.end_of_word(str, cursorcol, linelen, big_word)
             if next_char_class == cc.whitespace then
                 --next word is single char
                 rev_offset = next_word_start
-            elseif c_class == cc.punctuation then
+            elseif c_class == cc.punctuation and next_char_class ~= cc.punctuation then
                 --next word starts with punctuation
                 rev_offset = next_word_start
             else

--- a/lua/precognition/horizontal_motions.lua
+++ b/lua/precognition/horizontal_motions.lua
@@ -91,9 +91,13 @@ function M.end_of_word(str, cursorcol, linelen, big_word)
     if c_class == cc.whitespace or next_char_class == cc.whitespace then
         local next_word_start = M.next_word_boundary(str, cursorcol, linelen, big_word)
         if next_word_start then
+            c_class = utils.char_class(vim.fn.strcharpart(str, next_word_start - 1, 1), big_word)
             next_char_class = utils.char_class(vim.fn.strcharpart(str, (next_word_start - 1) + 1, 1), big_word)
-            --next word is single char
             if next_char_class == cc.whitespace then
+                --next word is single char
+                rev_offset = next_word_start
+            elseif c_class == cc.punctuation then
+                --next word starts with punctuation
                 rev_offset = next_word_start
             else
                 rev_offset = M.end_of_word(str, next_word_start, linelen, big_word)

--- a/tests/precognition/horizontal_motions_spec.lua
+++ b/tests/precognition/horizontal_motions_spec.lua
@@ -316,4 +316,9 @@ describe("edge case", function()
         eq(3, hm.prev_word_boundary(str, 18, len, true))
         eq(3, hm.prev_word_boundary(str, 5, len, false))
     end)
+
+    it("quoted strings", function()
+        local str = 'this = "that"'
+        eq(8, hm.end_of_word(str, 6, #str, false))
+    end)
 end)

--- a/tests/precognition/horizontal_motions_spec.lua
+++ b/tests/precognition/horizontal_motions_spec.lua
@@ -320,5 +320,8 @@ describe("edge case", function()
     it("quoted strings", function()
         local str = 'this = "that"'
         eq(8, hm.end_of_word(str, 6, #str, false))
+
+        str = 'b = "^", c = 2 },'
+        eq(8, hm.end_of_word(str, 3, #str, false))
     end)
 end)


### PR DESCRIPTION
This commit improves the handling of quoted strings in word boundaries. The `end_of_word` function now correctly identifies the end of a word when the next word starts with punctuation or is a single character. A new test case has been added to verify this behavior.

closes #67 