### PR TITLE
fix: support calling setup() w/o args

### DIFF
--- a/lua/precognition/init.lua
+++ b/lua/precognition/init.lua
@@ -419,7 +419,8 @@ end
 
 ---@param opts Precognition.PartialConfig
 function M.setup(opts)
-    config = vim.tbl_deep_extend("force", default, opts or {})
+    opts = opts or {}
+    config = vim.tbl_deep_extend("force", default, opts)
     if opts.highlightColor then
         config.highlightColor = opts.highlightColor
     end


### PR DESCRIPTION
Avoids error `attempt to index local 'opts' (a nil value)` when calling `setup()` without arguments.

I noticed the issue when I updated the plugin.

Snippet of my `init.lua`, which does not pass arguments to `setup()`:
```lua
-- install w/ vim-plug
vim.call('plug#begin')
Plug('tris203/precognition.nvim')
vim.call('plug#end')

... 

require('precognition').setup()
```