### PR TITLE
feat: toggling returns visible value

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,16 @@ or
 require("precognition").toggle()
 ```
 
+The return value indicating the visible state can be used to produce a notification.
+
+```lua
+if require("precognition").toggle() then
+    vim.notify("precognition on")
+else
+    vim.notify("precognition off")
+end
+```
+
 The subcommands and functions `show` and `hide` are also available.
 
 ### Peeking

--- a/lua/precognition/init.lua
+++ b/lua/precognition/init.lua
@@ -407,12 +407,14 @@ function M.hide()
 end
 
 --- Toggle automatic showing of hints
+--- with return value indicating the visible state
 function M.toggle()
     if visible then
         M.hide()
     else
         M.show()
     end
+    return visible
 end
 
 ---@param opts Precognition.PartialConfig


### PR DESCRIPTION
Here is my first try with code changes and document updates in 2 commits.

In order to be consistent, I added return value for all `toggle`, `show`, and `hide`; but not for `peek`.

Let me know if you want to limit changes to `toggle` only.

closes #72 
