### PR TITLE
feat: add function to get visible state

### DIFF
--- a/lua/precognition/init.lua
+++ b/lua/precognition/init.lua
@@ -324,6 +324,7 @@ local function create_command()
         toggle = M.toggle,
         show = M.show,
         hide = M.hide,
+        visibleState = M.visibleState,
     }
 
     local function execute(args)
@@ -393,6 +394,11 @@ function M.show()
     })
 
     display_marks()
+end
+
+--- Return the current visibility state
+function M.visibleState()
+    return visible
 end
 
 --- Disable automatic showing of hints


### PR DESCRIPTION
pretty usefull when u want to ad some stuff upon state

allow to do something like this 

```lua
-- Plugin configuration
return {
  {
    "DrummyFloyd/precognition.nvim",
    event = "VeryLazy",
    branch = "add-visble-getter",
    opts = {
      startVisible = false,
    },
    keys = function()
      local p = require("precognition")
      LazyVim.toggle.map("<leader>uP", {
        name = "Precognition",
        get = function()
          return p.visibleState()
        end,
        set = function()
          p.toggle()
        end,
      })
    end,
  },
}

```