### PR TITLE
fix(utils): handle inlay hint label correctly

### DIFF
--- a/lua/precognition/utils.lua
+++ b/lua/precognition/utils.lua
@@ -73,8 +73,9 @@ end
 ---@return integer
 ---@return integer
 function M.calc_ws_offset(hint, tab_width, current_line)
+    local label = (hint.inlay_hint.label[1] and hint.inlay_hint.label[1].value) or hint.inlay_hint.label or ""
     -- + 1 here because of trailing padding
-    local length = #hint.inlay_hint.label[1].value + 1
+    local length = #label + 1
     local start = hint.inlay_hint.position.character
     local prefix = vim.fn.strcharpart(current_line, 0, start)
     local expanded = string.gsub(prefix, "\t", string.rep(" ", tab_width))


### PR DESCRIPTION
Previously, the inlay hint label handling did not account for cases where the label was not an array. This caused errors in calculating the offset for some LSP servers such as rust-analyzer

closes #81