### PR TITLE
feat(utils): enhance inlay hint spacing calculation

### DIFF
--- a/lua/precognition/utils.lua
+++ b/lua/precognition/utils.lua
@@ -70,12 +70,26 @@ end
 ---@param hint vim.lsp.inlay_hint.get.ret
 ---@param tab_width integer
 ---@param current_line string
----@return integer
----@return integer
+---@return integer length total padding required for the hint
+---@return integer offset offset where the padding starts
 function M.calc_ws_offset(hint, tab_width, current_line)
-    local label = (hint.inlay_hint.label[1] and hint.inlay_hint.label[1].value) or hint.inlay_hint.label or ""
-    -- + 1 here because of trailing padding
-    local length = #label + 1
+    ---@alias InlayHintLabelPartArray lsp.InlayHintLabelPart[]
+    local length = 0
+    if type(hint.inlay_hint.label) == "string" then
+        length = #hint.inlay_hint.label
+    elseif type(hint.inlay_hint.label) == "table" then
+        for _, v in
+            ipairs(hint.inlay_hint.label --[[@as InlayHintLabelPartArray]])
+        do
+            length = length + #v.value
+        end
+    end
+    if hint.inlay_hint.paddingLeft then
+        length = length + 1
+    end
+    if hint.inlay_hint.paddingRight then
+        length = length + 1
+    end
     local start = hint.inlay_hint.position.character
     local prefix = vim.fn.strcharpart(current_line, 0, start)
     local expanded = string.gsub(prefix, "\t", string.rep(" ", tab_width))

--- a/tests/precognition/inlay_hints_spec.lua
+++ b/tests/precognition/inlay_hints_spec.lua
@@ -1,5 +1,6 @@
 local server = require("tests.precognition.utils.lsp").server
 local compat = require("tests.precognition.utils.compat")
+local utils = require("precognition.utils")
 local precognition = require("precognition")
 ---@diagnostic disable-next-line: undefined-field
 local eq = assert.are.same
@@ -13,6 +14,91 @@ local function wait(condition, msg)
     neq(false, result, msg)
     neq(nil, result, msg)
 end
+
+describe("inlay hint utils", function()
+    it("calculates lua style inlay hints", function()
+        local length, wsoffset = utils.calc_ws_offset({
+            bufnr = 1,
+            client_id = 1,
+            inlay_hint = {
+                kind = 2,
+                label = {
+                    {
+                        location = {
+                            range = {
+                                ["end"] = {
+                                    character = 24,
+                                    line = 9,
+                                },
+                                start = {
+                                    character = 17,
+                                    line = 9,
+                                },
+                            },
+                            uri = "file:///home/tris/.local/share/nvim/mason/packages/lua-language-server/libexec/meta/LuaJIT%20en-us%20utf8/package.lua",
+                        },
+                        value = "modname:",
+                    },
+                },
+                paddingLeft = false,
+                paddingRight = true,
+                position = {
+                    character = 23,
+                    line = 0,
+                },
+            },
+        }, 2, [[local compat = require("precognition.compat")]])
+
+        eq(9, length)
+        eq(23, wsoffset)
+    end)
+
+    it("calculates rust style inlay hints", function()
+        local length, wsoffset = utils.calc_ws_offset({
+            bufnr = 1,
+            client_id = 1,
+            inlay_hint = {
+                data = {
+                    file_id = 0,
+                },
+                kind = 1,
+                label = {
+                    {
+                        value = ": ",
+                    },
+                    {
+                        location = {
+                            range = {
+                                ["end"] = {
+                                    character = 17,
+                                    line = 364,
+                                },
+                                start = {
+                                    character = 11,
+                                    line = 364,
+                                },
+                            },
+                            uri = "file:///home/tris/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/string.rs",
+                        },
+                        value = "String",
+                    },
+                    {
+                        value = "",
+                    },
+                },
+                paddingLeft = false,
+                paddingRight = false,
+                position = {
+                    character = 16,
+                    line = 7,
+                },
+            },
+        }, 2, [[        let body = res.text().await?;]])
+
+        eq(8, length)
+        eq(16, wsoffset)
+    end)
+end)
 
 describe("lsp based tests", function()
     before_each(function()

--- a/tests/precognition/utils/lsp.lua
+++ b/tests/precognition/utils/lsp.lua
@@ -21,6 +21,7 @@ function M.server()
                 {
                     position = { line = 0, character = 3 },
                     label = { { value = "foo" } },
+                    paddingLeft = true,
                 },
             })
         else


### PR DESCRIPTION
- Updated `calc_ws_offset` to handle different inlay hint label types
- Added tests for Lua and Rust style inlay hints
- Included padding adjustments for inlay hints

Fixes #94