### PR TITLE
chore(ci): bump actions/checkout to v5 in workflows

### DIFF
--- a/.github/workflows/dts.yml
+++ b/.github/workflows/dts.yml
@@ -16,7 +16,7 @@ jobs:
     name: DTS Tests
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - uses: rhysd/action-setup-vim@v1
         with:

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -14,7 +14,7 @@ jobs:
     name: Stylua
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - run: date +%W > weekly
 
       - name: Restore cache

--- a/.github/workflows/format_tests.yml
+++ b/.github/workflows/format_tests.yml
@@ -14,7 +14,7 @@ jobs:
     name: Stylua
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - run: date +%W > weekly
 
       - name: Restore cache

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
     name: Luacheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup
         run: |
             sudo apt-get update

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
     name: Plenary Tests
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - uses: rhysd/action-setup-vim@v1
         with:

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: stevearc/nvim-typecheck-action@v2
         with:
           level: Warning


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI pipelines (tests, linting, formatting, type checking) to use the latest checkout tooling, enhancing reliability and security of automation.
  * No changes to application behavior, features, or public APIs.
  * End users should not see any differences; this keeps build and verification workflows up to date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->