### PR TITLE
feat: add full-width virtual line highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ return {
     opts = {
     -- startVisible = true,
     -- showBlankVirtLine = true,
+    -- highlightFullVirtLine = false,
     -- highlightColor = { link = "Comment" },
     -- hints = {
     --      Caret = { text = "^", prio = 2 },
@@ -55,6 +56,10 @@ return {
 - `showBlankVirtLine = false`
   Setting this option will mean that if a Virtual Line would be blank it won't be
   rendered
+- `highlightFullVirtLine = true`
+  Pads Inline Hint virtual lines to the current window width. This is useful when
+  `highlightColor` includes a background color and you want that background to
+  extend across the whole visible row.
 - `gutterHints` can be hidden by setting their priority to 0.
 - `highlightColor` can be set in two ways:
 

--- a/lua/precognition/init.lua
+++ b/lua/precognition/init.lua
@@ -166,7 +166,7 @@ local function build_virt_line(marks, line_len, extra_padding, min_width)
         line = line .. string.rep(" ", min_width - vim.fn.strdisplaywidth(line))
     end
     if line:match("^%s+$") then
-        if min_width then
+        if min_width and config.showBlankVirtLine then
             return { { line, "PrecognitionHighlight" } }
         else
             return {}
@@ -311,7 +311,12 @@ local function display_marks()
 
     utils.add_multibyte_padding(cur_line, extra_padding, line_len)
 
-    local min_width = config.highlightFullVirtLine and vim.api.nvim_win_get_width(0) or nil
+    local min_width
+    if config.highlightFullVirtLine then
+        local win_info = vim.fn.getwininfo(vim.fn.win_getid())
+        local textoff = win_info and win_info[1] and win_info[1].textoff or 0
+        min_width = vim.api.nvim_win_get_width(0) - textoff
+    end
     local virt_line = build_virt_line(virtual_line_marks, line_len, extra_padding, min_width)
 
     -- TODO: can we add indent lines to the virt line to match indent-blankline or similar (if installed)?

--- a/lua/precognition/init.lua
+++ b/lua/precognition/init.lua
@@ -26,6 +26,7 @@ local M = {}
 ---@class Precognition.Config
 ---@field startVisible boolean
 ---@field showBlankVirtLine boolean
+---@field highlightFullVirtLine boolean
 ---@field highlightColor vim.api.keyset.highlight
 ---@field hints Precognition.HintConfig
 ---@field gutterHints Precognition.GutterHintConfig
@@ -34,6 +35,7 @@ local M = {}
 ---@class Precognition.PartialConfig
 ---@field startVisible? boolean
 ---@field showBlankVirtLine? boolean
+---@field highlightFullVirtLine? boolean
 ---@field highlightColor? vim.api.keyset.highlight
 ---@field hints? Precognition.HintConfig
 ---@field gutterHints? Precognition.GutterHintConfig
@@ -78,6 +80,7 @@ local defaultHintConfig = {
 local default = {
     startVisible = true,
     showBlankVirtLine = true,
+    highlightFullVirtLine = false,
     highlightColor = { link = "Comment" },
     hints = defaultHintConfig,
     gutterHints = {
@@ -115,8 +118,9 @@ local gutter_group = "precognition_gutter"
 ---@param marks Precognition.VirtLine
 ---@param line_len integer
 ---@param extra_padding Precognition.ExtraPadding[]
+---@param min_width? integer
 ---@return table
-local function build_virt_line(marks, line_len, extra_padding)
+local function build_virt_line(marks, line_len, extra_padding, min_width)
     local utils = require("precognition.utils")
     if not marks then
         return {}
@@ -158,8 +162,15 @@ local function build_virt_line(marks, line_len, extra_padding)
     end
 
     local line = table.concat(line_table)
+    if min_width and vim.fn.strdisplaywidth(line) < min_width then
+        line = line .. string.rep(" ", min_width - vim.fn.strdisplaywidth(line))
+    end
     if line:match("^%s+$") then
-        return {}
+        if min_width then
+            return { { line, "PrecognitionHighlight" } }
+        else
+            return {}
+        end
     end
     table.insert(virt_line, { line, "PrecognitionHighlight" })
     return virt_line
@@ -300,7 +311,8 @@ local function display_marks()
 
     utils.add_multibyte_padding(cur_line, extra_padding, line_len)
 
-    local virt_line = build_virt_line(virtual_line_marks, line_len, extra_padding)
+    local min_width = config.highlightFullVirtLine and vim.api.nvim_win_get_width(0) or nil
+    local virt_line = build_virt_line(virtual_line_marks, line_len, extra_padding, min_width)
 
     -- TODO: can we add indent lines to the virt line to match indent-blankline or similar (if installed)?
 

--- a/tests/precognition/e2e_spec.lua
+++ b/tests/precognition/e2e_spec.lua
@@ -224,6 +224,54 @@ describe("e2e tests", function()
         eq(customMark, vim.api.nvim_get_hl(0, { name = extmarks[3].virt_lines[1][1][2] }))
     end)
 
+    it("does not display blank full-width virtual lines when blank virtual lines are disabled", function()
+        precognition.setup({
+            showBlankVirtLine = false,
+            highlightFullVirtLine = true,
+            ---@diagnostic disable-next-line: missing-fields
+            hints = {
+                Caret = { prio = 0 },
+                w = { prio = 0 },
+                b = { prio = 0 },
+                e = { prio = 0 },
+                W = { prio = 0 },
+                B = { prio = 0 },
+                E = { prio = 0 },
+                MatchingPair = { prio = 0 },
+                Zero = { prio = 0 },
+                Dollar = { prio = 0 },
+            },
+        })
+        local buffer = vim.api.nvim_create_buf(true, false)
+        vim.api.nvim_set_current_buf(buffer)
+        vim.api.nvim_buf_set_lines(buffer, 0, -1, false, { "Hello" })
+        vim.api.nvim_win_set_cursor(0, { 1, 0 })
+
+        precognition.on_cursor_moved()
+
+        local extmarks = vim.api.nvim_buf_get_extmarks(buffer, precognition.ns, 0, -1, { details = true })
+        eq(0, #extmarks)
+    end)
+
+    it("pads full-width virtual lines to the text area", function()
+        precognition.setup({ highlightFullVirtLine = true })
+        local buffer = vim.api.nvim_create_buf(true, false)
+        vim.api.nvim_set_current_buf(buffer)
+        vim.api.nvim_buf_set_lines(buffer, 0, -1, false, { "Hello World" })
+        vim.api.nvim_win_set_width(0, 40)
+        vim.wo.number = true
+        vim.wo.signcolumn = "yes"
+        vim.api.nvim_win_set_cursor(0, { 1, 0 })
+
+        precognition.on_cursor_moved()
+
+        local extmarks = vim.api.nvim_buf_get_extmark_by_id(buffer, precognition.ns, precognition.extmark, {
+            details = true,
+        })
+        local win_info = vim.fn.getwininfo(vim.fn.win_getid())[1]
+        eq(vim.api.nvim_win_get_width(0) - win_info.textoff, #extmarks[3].virt_lines[1][1][1])
+    end)
+
     it("preserves highlight groups through a colorscheme change", function()
         vim.cmd.colorscheme("default")
         local hl = vim.api.nvim_get_hl(0, { name = "PrecognitionHighlight" })

--- a/tests/precognition/e2e_spec.lua
+++ b/tests/precognition/e2e_spec.lua
@@ -255,6 +255,9 @@ describe("e2e tests", function()
 
     it("pads full-width virtual lines to the text area", function()
         precognition.setup({ highlightFullVirtLine = true })
+        local orig_width = vim.api.nvim_win_get_width(0)
+        local orig_number = vim.wo.number
+        local orig_signcolumn = vim.wo.signcolumn
         local buffer = vim.api.nvim_create_buf(true, false)
         vim.api.nvim_set_current_buf(buffer)
         vim.api.nvim_buf_set_lines(buffer, 0, -1, false, { "Hello World" })
@@ -270,6 +273,9 @@ describe("e2e tests", function()
         })
         local win_info = vim.fn.getwininfo(vim.fn.win_getid())[1]
         eq(vim.api.nvim_win_get_width(0) - win_info.textoff, #extmarks[3].virt_lines[1][1][1])
+        vim.wo.number = orig_number
+        vim.wo.signcolumn = orig_signcolumn
+        vim.api.nvim_win_set_width(0, orig_width)
     end)
 
     it("preserves highlight groups through a colorscheme change", function()

--- a/tests/precognition/virtline_spec.lua
+++ b/tests/precognition/virtline_spec.lua
@@ -160,6 +160,32 @@ describe("Build Virtual Line", function()
         eq(#line + total_added, #virt_line[1][1])
     end)
 
+    it("can pad a virtual line to a minimum width", function()
+        local marks = {
+            Caret = 4,
+            Dollar = 10,
+        }
+        local virtual_line = precognition.build_virt_line(marks, 10, {}, 20)
+        eq("   ^     $          ", virtual_line[1][1])
+        eq(20, #virtual_line[1][1])
+    end)
+
+    it("does not truncate a virtual line longer than the minimum width", function()
+        local marks = {
+            Caret = 4,
+            Dollar = 10,
+        }
+        local virtual_line = precognition.build_virt_line(marks, 10, {}, 5)
+        eq("   ^     $", virtual_line[1][1])
+        eq(10, #virtual_line[1][1])
+    end)
+
+    it("can render a blank virtual line when padding to a minimum width", function()
+        local virtual_line = precognition.build_virt_line({}, 5, {}, 12)
+        eq("            ", virtual_line[1][1])
+        eq(12, #virtual_line[1][1])
+    end)
+
     it("example virtual line with emoji", function()
         local line = "# 💭👀precognition.nvim"
         local cursorcol = 20


### PR DESCRIPTION
## Summary
- Add a `highlightFullVirtLine` option to pad inline hint virtual lines to the current window width.
- Preserve default behavior by leaving full-line highlighting disabled unless opted in.
- Document the option and cover padding behavior with virtual-line tests.

Closes #93

## Tests
- `make test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a setting to pad inline hint lines so highlight background extends across the full visible window width.

* **Documentation**
  * README installation/config now documents the new setting and shows an example configuration.

* **Tests**
  * Added unit and end-to-end tests verifying full-width virtual line padding and rendering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->