### PR TITLE
test(e2e): add screenshot and utils for count/textobj

### DIFF
--- a/tests/precognition/test_count_motions_e2e.lua
+++ b/tests/precognition/test_count_motions_e2e.lua
@@ -1,6 +1,9 @@
 local precognition = require("precognition")
 local eq = MiniTest.expect.equality
+local ss = MiniTest.expect.reference_screenshot
+local child = MiniTest.new_child_neovim()
 local original_get_mode = vim.api.nvim_get_mode
+local test_utils = require("tests.precognition.utils.utils")
 
 local function get_gutter_extmarks(buffer)
     local gutter_extmarks = {}
@@ -51,6 +54,9 @@ describe("e2e tests", function()
 
     after_each(function()
         rawset(vim.api, "nvim_get_mode", original_get_mode)
+        if child.is_running() then
+            child.stop()
+        end
     end)
 
     it("auto commands are set", function()
@@ -249,6 +255,17 @@ describe("e2e tests", function()
         eq("b         e w            $", extmarks[3].virt_lines[1][1][1])
     end)
 
+    it("screenshots counted hints from typed input", function()
+        child.restart({ "-u", "scripts/minimal_init.lua" })
+        child.lua_func(function()
+            local precognition = require("precognition")
+            precognition.setup({ targetedMotionHints = { enabled = false } })
+            vim.api.nvim_buf_set_lines(0, 0, -1, false, { "Hello World this is a test" })
+            vim.api.nvim_win_set_cursor(0, { 1, 6 })
+        end)
+        test_utils.show_with_motion_count(child, "2")
+        ss(child.get_screenshot({ redraw = false }))
+    end)
     it("does not treat leading zero as a motion count", function()
         rawset(vim.api, "nvim_get_mode", function()
             return { mode = "n" }
@@ -408,5 +425,50 @@ describe("e2e tests", function()
         })
         eq("^                        $", extmarks[3].virt_lines[1][1][1])
         eq(3, #get_gutter_extmarks(buffer))
+    end)
+
+    it("clears hints for counts above 100", function()
+        child.restart({ "-u", "scripts/minimal_init.lua" })
+        child.lua_func(function()
+            local precognition = require("precognition")
+            precognition.setup({
+                showBlankVirtLine = false,
+                targetedMotionHints = { enabled = false },
+                hints = {
+                    Caret = { prio = 0 },
+                    Dollar = { prio = 0 },
+                    MatchingPair = { prio = 0 },
+                    Zero = { prio = 0 },
+                    b = { prio = 0 },
+                    e = { prio = 0 },
+                    w = { prio = 0 },
+                },
+                gutterHints = {
+                    G = { prio = 0 },
+                    NextParagraph = { prio = 0 },
+                    PrevParagraph = { prio = 0 },
+                    gg = { prio = 0 },
+                },
+            })
+            vim.api.nvim_buf_set_lines(0, 0, -1, false, { "Hello World this is a test", "line 2" })
+            vim.api.nvim_win_set_cursor(0, { 1, 6 })
+        end)
+        test_utils.show_with_motion_count(child, "101")
+        ss(child.get_screenshot())
+    end)
+
+    it("ignores operator-pending counts", function()
+        child.restart({ "-u", "scripts/minimal_init.lua" })
+        child.lua_func(function()
+            local precognition = require("precognition")
+            rawset(vim.api, "nvim_get_mode", function()
+                return { mode = "no" }
+            end)
+            precognition.setup({ targetedMotionHints = { enabled = false } })
+            vim.api.nvim_buf_set_lines(0, 0, -1, false, { "Hello World this is a test" })
+            vim.api.nvim_win_set_cursor(0, { 1, 6 })
+            vim.api.nvim_exec_autocmds("CursorMoved", { group = "precognition" })
+        end)
+        ss(child.get_screenshot())
     end)
 end)

--- a/tests/precognition/test_text_objects.lua
+++ b/tests/precognition/test_text_objects.lua
@@ -1,6 +1,9 @@
 local precognition = require("precognition")
 local eq = MiniTest.expect.equality
+local ss = MiniTest.expect.reference_screenshot
+local child = MiniTest.new_child_neovim()
 local original_get_mode = vim.api.nvim_get_mode
+local test_utils = require("tests.precognition.utils.utils")
 
 local function text_object_extmark()
     local ns = vim.api.nvim_create_namespace("precognition")
@@ -37,6 +40,9 @@ describe("text object hints", function()
     after_each(function()
         rawset(vim.api, "nvim_get_mode", original_get_mode)
         pcall(precognition.hide)
+        if child.is_running() then
+            child.stop()
+        end
     end)
 
     it("switches from motion hints to inside text object hints", function()
@@ -181,6 +187,52 @@ describe("text object hints", function()
         eq(true, groups.PrecognitionTextObjectRange1)
         eq(true, groups.PrecognitionTextObjectRange2)
         eq(true, groups.PrecognitionTextObjectRange3)
+    end)
+
+    it("screenshots inside text object hints with stacked ranges", function()
+        child.restart({ "-u", "scripts/minimal_init.lua" })
+        child.lua_func(function()
+            local precognition = require("precognition")
+            precognition.setup()
+            vim.api.nvim_buf_set_lines(0, 0, -1, false, { 'call({ key = "value" })' })
+            vim.api.nvim_win_set_cursor(0, { 1, 15 })
+        end)
+        test_utils.show_with_pending_prefix(child, "di")
+
+        child.lua_func(function()
+            local eq = MiniTest.expect.equality
+            local ns = vim.api.nvim_create_namespace("precognition")
+            local extmark = vim.api.nvim_buf_get_extmarks(0, ns, 0, -1, { details = true })[1]
+            local text = ""
+            for _, chunk in ipairs(extmark[4].virt_lines[1]) do
+                text = text .. chunk[1]
+            end
+            eq('    ({       "    w" })', text)
+        end)
+        ss(child.get_screenshot({ redraw = false }))
+    end)
+
+    it("screenshots around text object hints with stacked ranges", function()
+        child.restart({ "-u", "scripts/minimal_init.lua" })
+        child.lua_func(function()
+            local precognition = require("precognition")
+            precognition.setup()
+            vim.api.nvim_buf_set_lines(0, 0, -1, false, { 'call({ key = "value" })' })
+            vim.api.nvim_win_set_cursor(0, { 1, 15 })
+        end)
+        test_utils.show_with_pending_prefix(child, "da")
+
+        child.lua_func(function()
+            local eq = MiniTest.expect.equality
+            local ns = vim.api.nvim_create_namespace("precognition")
+            local extmark = vim.api.nvim_buf_get_extmarks(0, ns, 0, -1, { details = true })[1]
+            local text = ""
+            for _, chunk in ipairs(extmark[4].virt_lines[1]) do
+                text = text .. chunk[1]
+            end
+            eq('    ({       "    w"W})', text)
+        end)
+        ss(child.get_screenshot({ redraw = false }))
     end)
 
     it("customises text object range highlights", function()

--- a/tests/precognition/test_text_objects.lua
+++ b/tests/precognition/test_text_objects.lua
@@ -192,46 +192,24 @@ describe("text object hints", function()
     it("screenshots inside text object hints with stacked ranges", function()
         child.restart({ "-u", "scripts/minimal_init.lua" })
         child.lua_func(function()
-            local precognition = require("precognition")
-            precognition.setup()
+            require("precognition").setup({})
             vim.api.nvim_buf_set_lines(0, 0, -1, false, { 'call({ key = "value" })' })
             vim.api.nvim_win_set_cursor(0, { 1, 15 })
         end)
         test_utils.show_with_pending_prefix(child, "di")
 
-        child.lua_func(function()
-            local eq = MiniTest.expect.equality
-            local ns = vim.api.nvim_create_namespace("precognition")
-            local extmark = vim.api.nvim_buf_get_extmarks(0, ns, 0, -1, { details = true })[1]
-            local text = ""
-            for _, chunk in ipairs(extmark[4].virt_lines[1]) do
-                text = text .. chunk[1]
-            end
-            eq('    ({       "    w" })', text)
-        end)
         ss(child.get_screenshot({ redraw = false }))
     end)
 
     it("screenshots around text object hints with stacked ranges", function()
         child.restart({ "-u", "scripts/minimal_init.lua" })
         child.lua_func(function()
-            local precognition = require("precognition")
-            precognition.setup()
+            require("precognition").setup({})
             vim.api.nvim_buf_set_lines(0, 0, -1, false, { 'call({ key = "value" })' })
             vim.api.nvim_win_set_cursor(0, { 1, 15 })
         end)
         test_utils.show_with_pending_prefix(child, "da")
 
-        child.lua_func(function()
-            local eq = MiniTest.expect.equality
-            local ns = vim.api.nvim_create_namespace("precognition")
-            local extmark = vim.api.nvim_buf_get_extmarks(0, ns, 0, -1, { details = true })[1]
-            local text = ""
-            for _, chunk in ipairs(extmark[4].virt_lines[1]) do
-                text = text .. chunk[1]
-            end
-            eq('    ({       "    w"W})', text)
-        end)
         ss(child.get_screenshot({ redraw = false }))
     end)
 

--- a/tests/precognition/utils/utils.lua
+++ b/tests/precognition/utils/utils.lua
@@ -1,17 +1,19 @@
 local M = {}
 
 local function show_with_display_marks_upvalue(child, upvalue_name, prefix)
-    child.lua_func(function(name_to_set, prefix_to_set)
+    child.lua_func(function(upvalue_name_to_set, name_to_set, prefix_to_set)
         local precognition = require("precognition")
         precognition.hide()
 
         local _, display_marks = debug.getupvalue(precognition.peek, 1)
+        local found = false
         for index = 1, math.huge do
             local name, value = debug.getupvalue(display_marks, index)
             if name == nil then
                 break
             end
             if name == name_to_set then
+                found = true
                 if value and value.set_prefix then
                     value:set_prefix(prefix_to_set)
                 else
@@ -20,9 +22,10 @@ local function show_with_display_marks_upvalue(child, upvalue_name, prefix)
                 break
             end
         end
+        assert(found, string.format("Expected upvalue %q to contain %q", upvalue_name_to_set, name_to_set))
         precognition.show()
         vim.api.nvim__redraw({ buf = vim.api.nvim_get_current_buf(), flush = true })
-    end, upvalue_name, prefix)
+    end, "display_marks", upvalue_name, prefix)
 end
 
 function M.show_with_pending_prefix(child, prefix)

--- a/tests/precognition/utils/utils.lua
+++ b/tests/precognition/utils/utils.lua
@@ -1,5 +1,38 @@
 local M = {}
 
+local function show_with_display_marks_upvalue(child, upvalue_name, prefix)
+    child.lua_func(function(name_to_set, prefix_to_set)
+        local precognition = require("precognition")
+        precognition.hide()
+
+        local _, display_marks = debug.getupvalue(precognition.peek, 1)
+        for index = 1, math.huge do
+            local name, value = debug.getupvalue(display_marks, index)
+            if name == nil then
+                break
+            end
+            if name == name_to_set then
+                if value and value.set_prefix then
+                    value:set_prefix(prefix_to_set)
+                else
+                    debug.setupvalue(display_marks, index, prefix_to_set)
+                end
+                break
+            end
+        end
+        precognition.show()
+        vim.api.nvim__redraw({ buf = vim.api.nvim_get_current_buf(), flush = true })
+    end, upvalue_name, prefix)
+end
+
+function M.show_with_pending_prefix(child, prefix)
+    show_with_display_marks_upvalue(child, "pending_command_prefix", prefix)
+end
+
+function M.show_with_motion_count(child, prefix)
+    show_with_display_marks_upvalue(child, "motion_count", prefix)
+end
+
 function M.hex2dec(hex)
     hex = hex:gsub("#", "")
     local r = tonumber("0x" .. hex:sub(1, 2))


### PR DESCRIPTION
Add end-to-end tests that take reference screenshots for counted motion hints and text object hints, including stacked ranges and edge cases (counts above 100, operator-pending counts). Introduce utility functions in test_utils to manipulate upvalues for pending prefixes and motion counts, enabling precise test setup for visual regression.

This test files are already checked in and had previously become orphaned

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added screenshot-based end-to-end tests for counted motion hints, including large counts and operator-pending counts.
  * Added screenshot tests for text-object hint behavior (e.g., pending prefixes like "di"/"da").
  * Improved test lifecycle: initialized screenshot support and ensured the Neovim child process is stopped after each test.
  * Added test utilities to simulate pending prefixes and motion counts.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tris203/precognition.nvim/pull/123)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->