### PR TITLE
docs(scope): clarify out-of-scope for floating overlay hints

### DIFF
--- a/.out-of-scope/floating-overlay-hint-rendering.md
+++ b/.out-of-scope/floating-overlay-hint-rendering.md
@@ -1,0 +1,22 @@
+# Floating Overlay Hint Rendering
+
+Precognition does not support rendering Inline Hints with floating windows,
+overlay extmarks, or fake-transparent popups instead of virtual lines.
+
+## Why this is out of scope
+
+Precognition uses Neovim virtual lines as the rendering model for Inline Hints.
+Supporting a second renderer would add a parallel layout system with different
+tradeoffs from virtual lines: it can obscure buffer text, needs separate
+alignment behavior, and introduces difficult edge cases around wrapping, tabs,
+multibyte characters, inlay-hint padding, and text-object hints.
+
+Keeping one rendering method makes Hint behavior easier to reason about and
+keeps the implementation focused on showing Motion Destinations consistently.
+Configuration that changes where the virtual line appears, such as placing it
+above the cursor line, is a separate possibility because it preserves the same
+virtual-line rendering model.
+
+## Prior requests
+
+- #44 - "Support virtual line to be floating"


### PR DESCRIPTION
Add documentation explaining why floating window, overlay extmark, or popup-based rendering for inline hints is out of scope. This clarifies the project's focus on virtual line rendering and documents prior requests for alternative hint display methods.

##44

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation clarifying scope limitations for inline hint rendering, explaining design constraints and architectural tradeoffs related to the current hint display system.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tris203/precognition.nvim/pull/125)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->